### PR TITLE
Removed the restriction on "approved" methods.

### DIFF
--- a/lib/ansible/modules/network/basics/uri.py
+++ b/lib/ansible/modules/network/basics/uri.py
@@ -75,7 +75,7 @@ options:
     description:
       - The HTTP method of the request or response. It MUST be uppercase.
     required: false
-    choices: [ "GET", "POST", "PUT", "HEAD", "DELETE", "OPTIONS", "PATCH", "TRACE", "CONNECT", "REFRESH" ]
+    choices: [ "GET", "POST", "PUT", "HEAD", "DELETE", "OPTIONS", "PATCH", "TRACE", "CONNECT", "REFRESH", "..." ]
     default: "GET"
   return_content:
     description:
@@ -370,7 +370,7 @@ def main():
         url_password = dict(required=False, default=None, aliases=['password'], no_log=True),
         body = dict(required=False, default=None, type='raw'),
         body_format = dict(required=False, default='raw', choices=['raw', 'json']),
-        method = dict(required=False, default='GET', choices=['GET', 'POST', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'PATCH', 'TRACE', 'CONNECT', 'REFRESH']),
+        method = dict(required=False, default='GET'),
         return_content = dict(required=False, default='no', type='bool'),
         follow_redirects = dict(required=False, default='safe', choices=['all', 'safe', 'none', 'yes', 'no']),
         creates = dict(required=False, default=None, type='path'),


### PR DESCRIPTION
This restriction in the uri module is annoying and not helpful at all.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
network / basic / uri module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file = /Users/jris/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Removed the restriction on "approved" methods.
This is not helpful in any way.
A common use case would be to send a PURGE method to varnish, which is not an "approved" method, but it IS convention.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```